### PR TITLE
Added Jester to Networked Roles

### DIFF
--- a/lua/terrortown/entities/roles/infected/shared.lua
+++ b/lua/terrortown/entities/roles/infected/shared.lua
@@ -49,6 +49,9 @@ if CLIENT then
 end
 
 if SERVER then
+	function ROLE:Initialize()
+		if JESTER then self.networkRoles = {JESTER} end
+	end
 	-- Give Loadout on respawn and rolechange
 	function ROLE:GiveRoleLoadout(ply, isRoleChange)
 		ply:GiveEquipmentWeapon("weapon_ttt_inf_fists")


### PR DESCRIPTION
Added Jester to Networked roles so that they are able to see who the jester is and thus avoid killing them.